### PR TITLE
feat: Init command makes a config file if it doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Ratchet
+
+Ratchet is a tool for fixing up legacy codebases by adding new rules without requiring current violations to be immediately fixed. It takes heavy inspiration from [Betterer](https://phenomnomnominal.github.io/betterer/), but aims to be compatible and/or extensible to any programming language.
+
+## Installation
+
+TODO: Figure out distribution method. Probably multiple, depending on the language.
+
+## Usage
+
+There are currently three commands available:
+1. `ratchet init` - Initializes a new ratchet configuration file
+2. `ratchet turn` - Goes through the codebase for any violations and updates the tracking document accordingly
+3. `ratchet check` - Checks the current codebase against the previous tracking document to see if any new violations have been added (useful for CI jobs)
+
+More will be added over time and existing ones enhanced as the project matures.
+
+## Why Ratchet?
+Most code is "legacy" code. At some point, you'll be tasked with maintaining a codebase that lacks linting rules, is missing new language features, has a million TODOs, etc.. Ratchet helps you to fix up your codebase over time by introducing new rules without requiring the current code to follow those rules. This allows you to slowly improve the codebase without needing to stop all development to fix everything at once.
+
+Ratchet's ultimate goal is to be uninstalled from your codebase. As you've fixed each rule, you can remove it from Ratchet and add it to your tool's official configuration.
+
+## Contributing
+
+TODO: Add contributing guidelines and figure out the license

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,18 +1,37 @@
-use std::{collections::HashMap, fs};
+use std::{collections::HashMap, fs, io::Write};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
+pub const RATCHET_CONFIG: &str = "ratchet.toml";
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct RatchetConfig {
     pub version: u8,
     // TODO: I don't think I like this structure, revisit
     pub rules: HashMap<String, RatchetRule>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct RatchetRule {
     // TODO: Definitely revisit, not every rule is regex
     pub regex: String,
+}
+
+impl RatchetConfig {
+    pub fn init() {
+        let ratchet_config = RatchetConfig {
+            version: 1,
+            rules: HashMap::new(),
+        };
+
+        let toml = toml::to_string(&ratchet_config).expect("Failed to serialize");
+
+        let toml = format!("{}\n", toml);
+
+        let mut file = fs::File::create("ratchet.toml").expect("Failed to create file");
+        file.write_all(toml.as_bytes())
+            .expect("Failed to write to file");
+    }
 }
 
 pub fn read_config() -> RatchetConfig {

--- a/src/ratchet.rs
+++ b/src/ratchet.rs
@@ -6,10 +6,11 @@ use std::{
     collections::HashMap,
     fs::{read_to_string, File},
     io::Write,
+    path::Path,
 };
 use walkdir::WalkDir;
 
-use crate::config::read_config;
+use crate::config::{self, read_config, RATCHET_CONFIG};
 
 const RATCHET_FILE: &str = "ratchet.ron";
 
@@ -60,6 +61,14 @@ type MessageHash = String;
 
 pub fn init() {
     println!("initializing ratchet!");
+
+    let path = Path::new(RATCHET_CONFIG);
+    if path.exists() {
+        println!("Ratchet config already exists");
+        return;
+    }
+
+    config::RatchetConfig::init();
 }
 
 pub fn turn() {


### PR DESCRIPTION
# feat: Init command makes a config file if it doesn't exist

## What
- Makes the `init` command work
- Doesn't overwrite the existing file if it already exists
- Adds a basic `README`