### PR TITLE
chore: Add test for rename, tweaked return type for core logic function on and move saving elsewhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,7 @@ dependencies = [
  "clap",
  "regex",
  "ron",
+ "seahash",
  "serde",
  "toml",
  "walkdir",
@@ -240,6 +241,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ regex = "1.10.5"
 serde = { version = "1.0.203", features = ["derive"] }
 toml = "0.8.14"
 walkdir = "2.5.0"
+seahash = "4.1.0"

--- a/src/ratchet_file.rs
+++ b/src/ratchet_file.rs
@@ -220,4 +220,28 @@ mod test {
 
         assert!(!previous_file.compare_new(&new_file));
     }
+
+    #[test]
+    fn file_rename_no_changes_returns_same() {
+        let mut previous_rule_issues = super::RuleMap::new();
+        previous_rule_issues.insert(
+            ("file1".into(), 1234),
+            vec![(1, 2, "message".into(), "hash".into())],
+        );
+
+        let mut previous_file = super::RatchetFile::new();
+        previous_file
+            .rules
+            .insert(TEST_RULE_ONE.into(), previous_rule_issues);
+
+        let mut new_rule_issues = super::RuleMap::new();
+        new_rule_issues.insert(
+            ("file1_renamed".into(), 1234),
+            vec![(1, 2, "message".into(), "hash".into())],
+        );
+        let mut new_file = super::RatchetFile::new();
+        new_file.rules.insert(TEST_RULE_ONE.into(), new_rule_issues);
+
+        assert!(!previous_file.compare(&new_file));
+    }
 }


### PR DESCRIPTION
# chore: Add test for rename, tweaked return type for core logic function on and move saving elsewhere

## What
- Added test to check that a rule running on a renamed file would still be fine
- Changed the core logic function to return `got_worse` and the new `RatchetFile` so that the caller can decide what to do with it
- Adds `seahash` but doesn't use it (yet)