### PR TITLE
chore: Make lib.rs to control public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+mod config;
+mod ratchet;
+mod ratchet_file;
+
+pub use crate::ratchet::{init, turn, check, force};


### PR DESCRIPTION
# chore: Make lib.rs to control public API

## What
- Makes `lib.rs` to better organize the library API