### PR TITLE
chore: First pass of Rule trait

### DIFF
--- a/ratchet.ron
+++ b/ratchet.ron
@@ -6,7 +6,7 @@
                 "./src/ratchet.rs",
                 1234,
             ): [
-                /*[0]*/ (1301, 1305, "HACK( ALERT)?", "hash_me"),
+                /*[0]*/ (1312, 1316, "HACK( ALERT)?", "hash_me"),
             ],
         },
         "No more TODOs": {
@@ -22,26 +22,27 @@
                 "./src/config.rs",
                 1234,
             ): [
-                /*[0]*/ (389, 393, "TODO", "hash_me"),
-                /*[1]*/ (562, 566, "TODO", "hash_me"),
-                /*[2]*/ (642, 646, "TODO", "hash_me"),
-                /*[3]*/ (711, 715, "TODO", "hash_me"),
-                /*[4]*/ (787, 791, "TODO", "hash_me"),
-                /*[5]*/ (856, 860, "TODO", "hash_me"),
+                /*[0]*/ (215, 219, "TODO", "hash_me"),
+                /*[1]*/ (450, 454, "TODO", "hash_me"),
+                /*[2]*/ (620, 624, "TODO", "hash_me"),
+                /*[3]*/ (793, 797, "TODO", "hash_me"),
+                /*[4]*/ (873, 877, "TODO", "hash_me"),
+                /*[5]*/ (942, 946, "TODO", "hash_me"),
+                /*[6]*/ (1018, 1022, "TODO", "hash_me"),
+                /*[7]*/ (1087, 1091, "TODO", "hash_me"),
             ],
             (
                 "./src/main.rs",
                 1234,
             ): [
-                /*[0]*/ (369, 373, "TODO", "hash_me"),
+                /*[0]*/ (379, 383, "TODO", "hash_me"),
             ],
             (
                 "./src/ratchet.rs",
                 1234,
             ): [
-                /*[0]*/ (1487, 1491, "TODO", "hash_me"),
-                /*[1]*/ (1705, 1709, "TODO", "hash_me"),
-                /*[2]*/ (4005, 4009, "TODO", "hash_me"),
+                /*[0]*/ (1498, 1502, "TODO", "hash_me"),
+                /*[1]*/ (2880, 2884, "TODO", "hash_me"),
             ],
             (
                 "./src/ratchet_file.rs",

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,16 @@ pub const CONFIG_VERSION: u8 = 1;
 pub const RATCHET_CONFIG: &str = "ratchet.toml";
 
 // TODO: What else should be considered well known?
-pub const WELL_KNOWN_FILES: [&str; 3] = [RATCHET_FILE, RATCHET_CONFIG, ".git"];
+pub const WELL_KNOWN_FILES: [&str; 4] = [
+    // Ratchet specific
+    RATCHET_FILE,
+    RATCHET_CONFIG,
+    // No need to look in the git folder!
+    ".git",
+    // Rust specific
+    // TODO: What if they're not running from root directory
+    "./target",
+];
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RatchetConfig {
@@ -17,6 +26,7 @@ pub struct RatchetConfig {
     pub rules: BTreeMap<String, RatchetRule>,
 }
 
+// TODO: Unify with the RegexRule, make the config just take Rule implementations
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RatchetRule {
     // TODO: Definitely revisit, not every rule is regex

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod config;
 mod ratchet;
 mod ratchet_file;
+mod rule;
 
 pub use crate::ratchet::{check, force, init, turn};

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use config::RATCHET_CONFIG;
 mod config;
 mod ratchet;
 mod ratchet_file;
+mod rule;
 
 /// Ratchet is a tool to help you add new rules to your project over time
 #[derive(Parser)]

--- a/src/rule.rs
+++ b/src/rule.rs
@@ -1,0 +1,73 @@
+use regex::Regex;
+
+pub trait Rule {
+    /// Default implementation to determine if a file should be analyzed
+    fn analyze_file(&self, path: &str) -> bool {
+        if self.include().is_some() {
+            let include = self.include().unwrap();
+            if !include.iter().any(|r| r.is_match(path)) {
+                return false;
+            }
+        }
+
+        if self.exclude().is_some() {
+            let exclude = self.exclude().unwrap();
+            if exclude.iter().any(|r| r.is_match(path)) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    // todo: what's this look like
+    fn check(&self, path: &str, content: &str) -> Vec<(usize, usize, String, String)>;
+
+    fn include(&self) -> Option<Vec<Regex>>;
+    fn exclude(&self) -> Option<Vec<Regex>>;
+}
+
+pub struct RegexRule {
+    pub regex: String,
+    pub include: Option<Vec<String>>,
+    pub exclude: Option<Vec<String>>,
+}
+
+impl Rule for RegexRule {
+    fn check(&self, path: &str, content: &str) -> Vec<(usize, usize, String, String)> {
+        let mut problems: Vec<(usize, usize, String, String)> = Vec::new();
+
+        let rule_regex = Regex::new(&self.regex).expect("Failed to compile regex");
+        let matches: Vec<_> = rule_regex.find_iter(content).collect();
+        println!("Found {} matches for {}", matches.len(), path);
+        for found in matches {
+            let value = (
+                found.start(),
+                found.end(),
+                rule_regex.to_string(),
+                "hash_me".to_string(),
+            );
+            problems.push(value);
+        }
+
+        problems
+    }
+
+    fn include(&self) -> Option<Vec<Regex>> {
+        self.include.as_ref().map(|include| {
+            include
+                .iter()
+                .map(|i| Regex::new(i).expect("Failed to compile include regex"))
+                .collect()
+        })
+    }
+
+    fn exclude(&self) -> Option<Vec<Regex>> {
+        self.exclude.as_ref().map(|exclude| {
+            exclude
+                .iter()
+                .map(|e| Regex::new(e).expect("Failed to compile include regex"))
+                .collect()
+        })
+    }
+}


### PR DESCRIPTION
# chore: First pass of Rule trait

## Why
- Right now there's only the one regex rule. There will be more! This PR starts on making a generic rule trait that can be implemented for anything we want to track

## What
- Adds `Rule` trait
- Implements it with `RegexRule`
- Updates main rule loop to use new `RegexRule`

## How
- Made the trait
- Created `include` and `exclude` methods on the `Rule` so that all rules can provide regex for how they should be run (if needed)
- Moved the regex-specific logic into a new `RegexRule` that implements `Rule`

## Testing
- Run the regular `force` and `check` commands, see that the output updates accordingly

## PR Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [x] Tests, linting, and formatting checks pass.
