### PR TITLE
fix: OS Consistency

### DIFF
--- a/packages/ratchet/src/lib.rs
+++ b/packages/ratchet/src/lib.rs
@@ -2,6 +2,7 @@ mod config;
 mod ratchet;
 mod ratchet_file;
 mod rule;
+mod utils;
 
 pub use crate::config::RATCHET_CONFIG;
 pub use crate::ratchet::{check, force, init, turn};

--- a/packages/ratchet/src/ratchet_file.rs
+++ b/packages/ratchet/src/ratchet_file.rs
@@ -57,7 +57,6 @@ impl RatchetFile {
             .separate_tuple_members(true)
             .enumerate_arrays(true);
         let ron = ron::ser::to_string_pretty(self, pretty_config).expect("Serialization failed");
-        let ron = format!("{}\n", ron);
 
         let mut file = File::create(file).expect("Failed to create file");
         file.write_all(ron.as_bytes())

--- a/packages/ratchet/src/utils.rs
+++ b/packages/ratchet/src/utils.rs
@@ -1,0 +1,33 @@
+use std::path::Path;
+
+use regex::Regex;
+
+/// Normalizes the path between operating systems
+/// by replacing any backslashes with forward slashes.
+pub fn to_normalized_path(path: &Path) -> String {
+    path.to_str().unwrap().replace("\\", "/")
+}
+
+/// Normalizes the file contents between operating systems
+/// by replacing any carriage returns with newlines.
+pub fn to_normalized_file_contents(contents: &str) -> String {
+    let re = Regex::new(r"\r\n|\r").expect("Failed to compile regex");
+    re.replace_all(contents, "\n").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_normalized_path() {
+        let path = Path::new("foo\\bar");
+        assert_eq!(to_normalized_path(path), "foo/bar");
+    }
+
+    #[test]
+    fn test_to_normalized_file_contents() {
+        let contents = "foo\r\nbar\r";
+        assert_eq!(to_normalized_file_contents(contents), "foo\nbar\n");
+    }
+}

--- a/ratchet.ron
+++ b/ratchet.ron
@@ -4,15 +4,15 @@
         "No more HACKS": {
             (
                 "./packages/ratchet/src/ratchet.rs",
-                1234,
+                1010763637869220865,
             ): [
-                /*[0]*/ (1312, 1316, "HACK( ALERT)?", "hash_me"),
+                /*[0]*/ (1374, 1378, "HACK( ALERT)?", "hash_me"),
             ],
         },
         "No more TODOs": {
             (
                 "./README.md",
-                1234,
+                12176637566222439714,
             ): [
                 /*[0]*/ (323, 327, "TODO", "hash_me"),
                 /*[1]*/ (1054, 1058, "TODO", "hash_me"),
@@ -20,13 +20,13 @@
             ],
             (
                 "./packages/ratchet-cli/src/main.rs",
-                1234,
+                3563840405771877954,
             ): [
                 /*[0]*/ (309, 313, "TODO", "hash_me"),
             ],
             (
                 "./packages/ratchet/src/config.rs",
-                1234,
+                2123751355126410226,
             ): [
                 /*[0]*/ (215, 219, "TODO", "hash_me"),
                 /*[1]*/ (450, 454, "TODO", "hash_me"),
@@ -40,14 +40,14 @@
             ],
             (
                 "./packages/ratchet/src/ratchet.rs",
-                1234,
+                1010763637869220865,
             ): [
-                /*[0]*/ (1498, 1502, "TODO", "hash_me"),
-                /*[1]*/ (2880, 2884, "TODO", "hash_me"),
+                /*[0]*/ (1560, 1564, "TODO", "hash_me"),
+                /*[1]*/ (3035, 3039, "TODO", "hash_me"),
             ],
             (
                 "./packages/ratchet/src/ratchet_file.rs",
-                1234,
+                10681399594338204015,
             ): [
                 /*[0]*/ (425, 429, "TODO", "hash_me"),
                 /*[1]*/ (716, 720, "TODO", "hash_me"),


### PR DESCRIPTION
# fix: OS Consistency

## Why
- Makes `ratchet.ron` file between OSes more consistent, fixes #22 

## What
- Deals with new lines better

## How
- Replace carriage returns (Windows style new lines) with just the newline character

## Testing
None, I should do some but I want to get this in and test it a bit more

## PR Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate).
- [x] Tests, linting, and formatting checks pass.
